### PR TITLE
FIX: empty array in tours if max amount sold

### DIFF
--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -1917,6 +1917,7 @@ export class UserPnL extends Entity {
 
     this.set("userId", Value.fromString(""));
     this.set("questionId", Value.fromString(""));
+    this.set("playerTokens", Value.fromBigInt(BigInt.zero()));
   }
 
   save(): void {
@@ -1961,6 +1962,15 @@ export class UserPnL extends Entity {
 
   set questionId(value: string) {
     this.set("questionId", Value.fromString(value));
+  }
+
+  get playerTokens(): BigInt {
+    let value = this.get("playerTokens");
+    return value!.toBigInt();
+  }
+
+  set playerTokens(value: BigInt) {
+    this.set("playerTokens", Value.fromBigInt(value));
   }
 
   get tours(): Array<string> | null {

--- a/schema.graphql
+++ b/schema.graphql
@@ -332,6 +332,7 @@ type UserPnL @entity {
   id: ID!
   userId: String!
   questionId: String!
+  playerTokens: BigInt!
   tours: [UserTourPlayerPnLTransaction!] @derivedFrom(field: "userPnl")
 }
 

--- a/src/FixedProductMarketMakerMapping.ts
+++ b/src/FixedProductMarketMakerMapping.ts
@@ -67,6 +67,7 @@ function updateUserPlayerPnLTransaction(
     let userPnlObj = new UserPnL(userId + "-" + fpmmId);
     userPnlObj.userId = userId;
     userPnlObj.questionId = questionId;
+    userPnlObj.playerTokens = tokensTraded;
     userPnlObj.save();
 
     let newPnLTourTxn = new UserTourPlayerPnLTransaction(id);
@@ -83,6 +84,12 @@ function updateUserPlayerPnLTransaction(
     return;
   }
   if (txnType === "Buy") {
+    let userPnlObj = UserPnL.load(userId + "-" + fpmmId);
+    if (userPnlObj != null) {
+      userPnlObj.playerTokens = userPnlObj.playerTokens.plus(tokensTraded);
+      userPnlObj.save();
+    }
+
     userPlayerPnLTransaction.tokens = userPlayerPnLTransaction.tokens.plus(
       tokensTraded
     );
@@ -93,6 +100,12 @@ function updateUserPlayerPnLTransaction(
     return;
   }
   if (userPlayerPnLTransaction.tokens.minus(tokensTraded) > new BigInt(0)) {
+    let userPnlObj = UserPnL.load(userId + "-" + fpmmId);
+    if (userPnlObj != null) {
+      userPnlObj.playerTokens = userPnlObj.playerTokens.minus(tokensTraded);
+      userPnlObj.save();
+    }
+
     userPlayerPnLTransaction.investmentAmount = userPlayerPnLTransaction.investmentAmount.minus(
       tradeAmount
     );


### PR DESCRIPTION
Added playerTokens in UserPnL so that if playerTokens are negligible, that player can be skipped from user holdings